### PR TITLE
Adding object removal (DELETE) functionality

### DIFF
--- a/MCAWSS3Client.h
+++ b/MCAWSS3Client.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, Mirego
+// Copyright (c) 2014, Mirego
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -45,17 +45,13 @@ typedef NS_ENUM(NSUInteger, MCAWSS3ObjectPermission) {
 @property (nonatomic, assign) BOOL integrityCheck;
 
 - (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
-
 - (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
-
 - (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
-
 - (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
 
 - (void)getObjectToFileAtPath:(NSString*)path key:(NSString*)key success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
 
 - (void)deleteObjectWithKey:(NSString*)key success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
-
 - (void)deleteObjectWithKey:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
 
 @end

--- a/MCAWSS3Client.h
+++ b/MCAWSS3Client.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, Mirego
+// Copyright (c) 2013, Mirego
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -25,18 +25,18 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#import <AFNetworking/AFNetworking.h>
+#import "AFHTTPRequestOperationManager.h"
 
-typedef enum {
+typedef NS_ENUM(NSUInteger, MCAWSS3ObjectPermission) {
     MCAWSS3ObjectPermissionsPrivate = 0,
     MCAWSS3ObjectPermissionPublicRead = 1,
     MCAWSS3ObjectPermissionPublicReadWrite = 2,
     MCAWSS3ObjectPermissionAuthenticatedRead = 3,
     MCAWSS3ObjectPermissionBucketOwnerRead = 4,
     MCAWSS3ObjectPermissionBucketOwnerFullControl = 5
-} MCAWSS3ObjectPermission;
+};
 
-@interface MCAWSS3Client : NSObject
+@interface MCAWSS3Client : AFHTTPRequestOperationManager
 
 @property (nonatomic, retain) NSString* accessKey;
 @property (nonatomic, retain) NSString* secretKey;
@@ -45,11 +45,17 @@ typedef enum {
 @property (nonatomic, assign) BOOL integrityCheck;
 
 - (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
-- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
 
-- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
 - (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
 
+- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
+
+- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
+
 - (void)getObjectToFileAtPath:(NSString*)path key:(NSString*)key success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
+
+- (void)deleteObjectWithKey:(NSString*)key success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
+
+- (void)deleteObjectWithKey:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure;
 
 @end

--- a/MCAWSS3Client.m
+++ b/MCAWSS3Client.m
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, Mirego
+// Copyright (c) 2013, Mirego
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -27,9 +27,9 @@
 
 #import "MCAWSS3Client.h"
 #import <CommonCrypto/CommonHMAC.h>
+#import "AFHTTPRequestOperation.h"
 
 @interface MCAWSS3Client ()
-@property (nonatomic) AFHTTPRequestOperationManager *requestOperationManager;
 - (NSString*)canonicalizedResourceWithKey:(NSString*)key;
 - (NSString*)stringToSignForRequestMethod:(NSString*)requestMethod contentMD5:(NSString*)contentMD5 mimeType:(NSString*)mimeType dateString:(NSString*)dateString headers:(NSString*)canonicalizedAmzHeaders resource:(NSString*)canonicalizedResource;
 - (NSString*)dateString;
@@ -45,134 +45,140 @@
     return [self initWithBaseURL:[NSURL URLWithString:@"http://s3.amazonaws.com"]];
 }
 
-- (instancetype)initWithBaseURL:(NSURL*)url
-{
-    if (self = [super init]) {
-        _requestOperationManager = [[AFHTTPRequestOperationManager alloc] initWithBaseURL:url];
+- (instancetype)initWithBaseURL:(NSURL*)url {
+    self = [super initWithBaseURL:url];
+    if (self) {
         _integrityCheck = YES;   //default
     }
     return self;
 }
 
-- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure
-{
+- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure {
     [self putObjectWithData:data key:key mimeType:mimeType permission:MCAWSS3ObjectPermissionsPrivate progress:NULL success:success failure:failure];
 }
 
-- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure
-{
+- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure {
     [self putObjectWithData:data key:key mimeType:mimeType permission:MCAWSS3ObjectPermissionsPrivate progress:progress success:success failure:failure];
 }
 
-- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure
-{
+- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure {
     [self putObjectWithData:data key:key mimeType:mimeType permission:permission progress:NULL success:success failure:failure];
 }
 
-- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure
-{
-    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
-    NSString* dateString = [self dateString];
-    [headers setObject:dateString forKey:@"Date"];
+- (void)putObjectWithData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure {
+    [self performMethod:@"PUT" withData:data key:key mimeType:mimeType permission:permission progress:progress success:success failure:failure];
+}
 
+- (void)deleteObjectWithKey:(NSString*)key success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure {
+    [self deleteObjectWithKey:key mimeType:@"" permission:MCAWSS3ObjectPermissionsPrivate progress:NULL success:success failure:failure];
+}
+
+- (void)deleteObjectWithKey:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure {
+    [self performMethod:@"DELETE" withData:[NSData data] key:key mimeType:mimeType permission:permission progress:progress success:success failure:failure];
+}
+
+- (void)performMethod:(NSString *)requestMethod withData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure {
+    [self.requestSerializer clearAuthorizationHeader];
+    
+    NSString* dateString = [self dateString];
+    [self.requestSerializer setValue:dateString forHTTPHeaderField:@"Date"];
+    
     NSString* contentMD5 = @"";
     if (self.integrityCheck) {
         contentMD5 = [self base64EncodedStringFromData:[self MD5FromData:data]];
-        [headers setObject:contentMD5 forKey:@"Content-MD5"];
+        [self.requestSerializer setValue:contentMD5 forHTTPHeaderField:@"Content-MD5"];
     }
-
+    
     NSMutableArray* xAmzHeaders = [[NSMutableArray alloc] init];
-
+    NSString *aclHeaderField = @"x-amz-acl";
+    
     switch (permission) {
         case MCAWSS3ObjectPermissionsPrivate:
-            [headers setObject:@"private" forKey:@"x-amz-acl"];
+            [self.requestSerializer setValue:@"private" forHTTPHeaderField:aclHeaderField];
             break;
         case MCAWSS3ObjectPermissionPublicRead:
-            [headers setObject:@"public-read" forKey:@"x-amz-acl"];
+            [self.requestSerializer setValue:@"public-read" forHTTPHeaderField:aclHeaderField];
             break;
         case MCAWSS3ObjectPermissionPublicReadWrite:
-            [headers setObject:@"public-read-write" forKey:@"x-amz-acl"];
+            [self.requestSerializer setValue:@"public-read-write" forHTTPHeaderField:aclHeaderField];
             break;
         case MCAWSS3ObjectPermissionAuthenticatedRead:
-            [headers setObject:@"authenticated-read" forKey:@"x-amz-acl"];
+            [self.requestSerializer setValue:@"authenticated-read" forHTTPHeaderField:aclHeaderField];
             break;
         case MCAWSS3ObjectPermissionBucketOwnerRead:
-            [headers setObject:@"bucket-owner-read" forKey:@"x-amz-acl"];
+            [self.requestSerializer setValue:@"bucket-owner-read" forHTTPHeaderField:aclHeaderField];
             break;
         case MCAWSS3ObjectPermissionBucketOwnerFullControl:
-            [headers setObject:@"bucket-owner-full-control" forKey:@"x-amz-acl"];
+            [self.requestSerializer setValue:@"bucket-owner-full-control" forHTTPHeaderField:aclHeaderField];
             break;
     }
     [xAmzHeaders addObject:@"x-amz-acl"];
-
-    if (self.sessionToken) {
-        [headers setObject:self.sessionToken forKey:@"x-amz-security-token"];
+    
+    if (_sessionToken) {
+        [self.requestSerializer setValue:_sessionToken forHTTPHeaderField:@"x-amz-security-token"];
         [xAmzHeaders addObject:@"x-amz-security-token"];
     }
-
+    
     [xAmzHeaders sortUsingSelector:@selector(compare:)];
     NSString* canonicalizedAmzHeaders = @"";
     for (NSString* xAmzHeader in xAmzHeaders) {
-        NSString* headerValue = [headers objectForKey:xAmzHeader];
+        [self.requestSerializer setValue:@"private" forHTTPHeaderField:aclHeaderField];
+        NSString* headerValue = [[self.requestSerializer HTTPRequestHeaders] objectForKey:xAmzHeader];
         canonicalizedAmzHeaders = [canonicalizedAmzHeaders
-                                   stringByAppendingFormat:@"%@:%@\n", 
-                                   xAmzHeader, 
+                                   stringByAppendingFormat:@"%@:%@\n",
+                                   xAmzHeader,
                                    headerValue];
     }
-
-    NSString* requestMethod = @"PUT";
+    
     NSString* canonicalizedResource = [self canonicalizedResourceWithKey:key];
     NSString* stringToSign = [self stringToSignForRequestMethod:requestMethod contentMD5:contentMD5 mimeType:mimeType dateString:dateString headers:canonicalizedAmzHeaders resource:canonicalizedResource];
-
+    
     NSString* signature = [self base64EncodedStringFromData:[self HMACSHA1WithKey:self.secretKey string:stringToSign]];
     NSString* authorizationString = [NSString stringWithFormat:@"AWS %@:%@", self.accessKey, signature];
-    [headers setObject:authorizationString forKey:@"Authorization"];
+    [self.requestSerializer setValue:authorizationString forHTTPHeaderField:@"Authorization"];
     
-    [headers setObject:mimeType forKey:@"Content-Type"];
-    
-    NSMutableURLRequest *request = [[self.requestOperationManager requestSerializer] requestWithMethod:@"PUT" URLString:[[NSURL URLWithString:canonicalizedResource relativeToURL:_requestOperationManager.baseURL] absoluteString] parameters:nil error:nil];
-    [request setAllHTTPHeaderFields:headers];
+    NSMutableURLRequest* request = [self.requestSerializer requestWithMethod:requestMethod URLString:[[NSURL URLWithString:canonicalizedResource relativeToURL:self.baseURL] absoluteString] parameters:nil error:nil];
     [request addValue:[NSString stringWithFormat:@"%ld", (long)[data length]] forHTTPHeaderField:@"Content-Length"];
     [request setHTTPBody:data];
-    AFHTTPRequestOperation *requestOperation = [self.requestOperationManager HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
+    
+    AFHTTPRequestOperation* operation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation* operation, id responseObject) {
         if (success) success(operation, responseObject);
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(AFHTTPRequestOperation* operation, NSError* error) {
         if (failure) failure(operation, error);
     }];
-    if (progress) {
-        [requestOperation setUploadProgressBlock:progress];
-    }
-
-    [self.requestOperationManager.operationQueue addOperation:requestOperation];
+    if (progress)
+        [operation setUploadProgressBlock:progress];
+    
+    [self.operationQueue addOperation:operation];
 }
 
 - (void)getObjectToFileAtPath:(NSString*)path key:(NSString*)key success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure
 {
-    NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
+    [self.requestSerializer clearAuthorizationHeader];
     
     NSString* dateString = [self dateString];
-    [headers setObject:dateString forKey:@"Date"];
-
+    [self.requestSerializer setValue:dateString forHTTPHeaderField:@"Date"];
+    
     NSString* canonicalizedAmzHeaders = @"";
     NSString* requestMethod = @"GET";
     NSString* canonicalizedResource = [self canonicalizedResourceWithKey:key];
     NSString* stringToSign = [self stringToSignForRequestMethod:requestMethod contentMD5:@"" mimeType:@"" dateString:dateString headers:canonicalizedAmzHeaders resource:canonicalizedResource];
-
+    
     NSString* signature = [self base64EncodedStringFromData:[self HMACSHA1WithKey:self.secretKey string:stringToSign]];
     NSString* authorizationString = [NSString stringWithFormat:@"AWS %@:%@", self.accessKey, signature];
-    [headers setObject:authorizationString forKey:@"Authorization"];
-
-    NSMutableURLRequest *request = [[self.requestOperationManager requestSerializer] requestWithMethod:@"PUT" URLString:[[NSURL URLWithString:canonicalizedResource relativeToURL:_requestOperationManager.baseURL] absoluteString] parameters:nil error:nil];
-    [request setAllHTTPHeaderFields:headers];
+    [self.requestSerializer setValue:authorizationString forHTTPHeaderField:@"Authorization"];
     
-    AFHTTPRequestOperation *requestOperation = [self.requestOperationManager HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation *operation, id responseObject) {
+    NSMutableURLRequest* request = [self.requestSerializer requestWithMethod:requestMethod URLString:[[NSURL URLWithString:canonicalizedResource relativeToURL:self.baseURL] absoluteString] parameters:nil error:nil];
+    
+    AFHTTPRequestOperation* operation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation* operation, id responseObject) {
         if (success) success(operation, responseObject);
-    } failure:^(AFHTTPRequestOperation *operation, NSError *error) {
+    } failure:^(AFHTTPRequestOperation* operation, NSError* error) {
         if (failure) failure(operation, error);
     }];
     
-    [requestOperation setOutputStream:[NSOutputStream outputStreamToFileAtPath:path append:NO]];
-    [self.requestOperationManager.operationQueue addOperation:requestOperation];
+    [operation setOutputStream:[NSOutputStream outputStreamToFileAtPath:path append:NO]];
+    
+    [self.operationQueue addOperation:operation];
 }
 
 
@@ -187,6 +193,9 @@
 
 - (NSString*)stringToSignForRequestMethod:(NSString*)requestMethod contentMD5:(NSString*)contentMD5 mimeType:(NSString*)mimeType dateString:(NSString*)dateString headers:(NSString*)canonicalizedAmzHeaders resource:(NSString*)canonicalizedResource
 {
+    if ([requestMethod isEqualToString:@"PUT"]) {
+        [self.requestSerializer setValue:mimeType forHTTPHeaderField:@"Content-Type"];
+    }
     return [NSString stringWithFormat:@"%@\n%@\n%@\n%@\n%@%@", requestMethod, contentMD5, mimeType, dateString, canonicalizedAmzHeaders, canonicalizedResource];
 }
 
@@ -194,10 +203,10 @@
 {
     NSUInteger length = [data length];
     NSMutableData* mutableData = [NSMutableData dataWithLength:((length + 2) / 3)*  4];
-
+    
     uint8_t* input = (uint8_t*)[data bytes];
     uint8_t* output = (uint8_t*)[mutableData mutableBytes];
-
+    
     for (NSUInteger i = 0; i < length; i += 3) {
         NSUInteger value = 0;
         for (NSUInteger j = i; j < (i + 3); j++) {
@@ -206,50 +215,50 @@
                 value |= (0xFF & input[j]);
             }
         }
-
+        
         static uint8_t const kAFBase64EncodingTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
+        
         NSUInteger idx = (i / 3)*  4;
         output[idx + 0] = kAFBase64EncodingTable[(value >> 18) & 0x3F];
         output[idx + 1] = kAFBase64EncodingTable[(value >> 12) & 0x3F];
         output[idx + 2] = (i + 1) < length ? kAFBase64EncodingTable[(value >> 6)  & 0x3F] : '=';
         output[idx + 3] = (i + 2) < length ? kAFBase64EncodingTable[(value >> 0)  & 0x3F] : '=';
     }
-
+    
     NSString* encodedString = [[NSString alloc] initWithData:mutableData encoding:NSASCIIStringEncoding];
     return encodedString;
 }
 
 - (NSData*)HMACSHA1WithKey:(NSString*)key string:(NSString*)string
 {
-	NSData* stringData = [string dataUsingEncoding:NSUTF8StringEncoding];
-	NSData* keyData = [key dataUsingEncoding:NSUTF8StringEncoding];
-
-	uint8_t digest[CC_SHA1_DIGEST_LENGTH] = {0};
-
-	CCHmacContext hmacContext;
-	CCHmacInit(&hmacContext, kCCHmacAlgSHA1, [keyData bytes], [keyData length]);
-	CCHmacUpdate(&hmacContext, [stringData bytes], [stringData length]);
-	CCHmacFinal(&hmacContext, digest);
-
-	return [NSData dataWithBytes:digest length:CC_SHA1_DIGEST_LENGTH];
+    NSData* stringData = [string dataUsingEncoding:NSUTF8StringEncoding];
+    NSData* keyData = [key dataUsingEncoding:NSUTF8StringEncoding];
+    
+    uint8_t digest[CC_SHA1_DIGEST_LENGTH] = {0};
+    
+    CCHmacContext hmacContext;
+    CCHmacInit(&hmacContext, kCCHmacAlgSHA1, [keyData bytes], [keyData length]);
+    CCHmacUpdate(&hmacContext, [stringData bytes], [stringData length]);
+    CCHmacFinal(&hmacContext, digest);
+    
+    return [NSData dataWithBytes:digest length:CC_SHA1_DIGEST_LENGTH];
 }
 
 - (NSData*)MD5FromData:(NSData*)data
 {
     uint8_t digest[CC_MD5_DIGEST_LENGTH] = {0};
-
-    CC_MD5([data bytes], [data length], digest);
-
+    
+    CC_MD5([data bytes], (int)[data length], digest);
+    
     return [NSData dataWithBytes:digest length:CC_MD5_DIGEST_LENGTH];
 }
 
 - (NSString*)URLEncodedStringFromString:(NSString*)string encoding:(NSStringEncoding)encoding
 {
     static NSString* const kAFLegalCharactersToBeEscaped = @"?!@#$^&%*+,:;='\"`<>()[]{}/\\|~ ";
-
+    
     // Following the suggestion in documentation for `CFURLCreateStringByAddingPercentEscapes` to "pre-process" URL strings (using stringByReplacingPercentEscapesUsingEncoding) with unpredictable sequences that may already contain percent escapes.
-	NSString* encodedURL = (__bridge_transfer NSString*)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)[string stringByReplacingPercentEscapesUsingEncoding:encoding], NULL, (__bridge CFStringRef)kAFLegalCharactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding));
+    NSString* encodedURL = (__bridge_transfer NSString*)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)[string stringByReplacingPercentEscapesUsingEncoding:encoding], NULL, (__bridge CFStringRef)kAFLegalCharactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding));
     return encodedURL;
 }
 
@@ -259,7 +268,7 @@
     [dateFormatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
     [dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
     [dateFormatter setDateFormat:@"EEE, d MMM yyyy HH:mm:ss Z"];
-
+    
     return [dateFormatter stringFromDate:[NSDate date]];
 }
 

--- a/MCAWSS3Client.m
+++ b/MCAWSS3Client.m
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, Mirego
+// Copyright (c) 2014, Mirego
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -79,19 +79,19 @@
 
 - (void)performMethod:(NSString *)requestMethod withData:(NSData*)data key:(NSString*)key mimeType:(NSString*)mimeType permission:(MCAWSS3ObjectPermission)permission progress:(void (^)(NSUInteger bytesWritten, long long totalBytesWritten, long long totalBytesExpectedToWrite))progress success:(void (^)(AFHTTPRequestOperation* operation, id responseObject))success failure:(void (^)(AFHTTPRequestOperation* operation, NSError* error))failure {
     [self.requestSerializer clearAuthorizationHeader];
-    
+
     NSString* dateString = [self dateString];
     [self.requestSerializer setValue:dateString forHTTPHeaderField:@"Date"];
-    
+
     NSString* contentMD5 = @"";
     if (self.integrityCheck) {
         contentMD5 = [self base64EncodedStringFromData:[self MD5FromData:data]];
         [self.requestSerializer setValue:contentMD5 forHTTPHeaderField:@"Content-MD5"];
     }
-    
+
     NSMutableArray* xAmzHeaders = [[NSMutableArray alloc] init];
     NSString *aclHeaderField = @"x-amz-acl";
-    
+
     switch (permission) {
         case MCAWSS3ObjectPermissionsPrivate:
             [self.requestSerializer setValue:@"private" forHTTPHeaderField:aclHeaderField];
@@ -113,12 +113,12 @@
             break;
     }
     [xAmzHeaders addObject:@"x-amz-acl"];
-    
+
     if (_sessionToken) {
         [self.requestSerializer setValue:_sessionToken forHTTPHeaderField:@"x-amz-security-token"];
         [xAmzHeaders addObject:@"x-amz-security-token"];
     }
-    
+
     [xAmzHeaders sortUsingSelector:@selector(compare:)];
     NSString* canonicalizedAmzHeaders = @"";
     for (NSString* xAmzHeader in xAmzHeaders) {
@@ -132,7 +132,7 @@
     
     NSString* canonicalizedResource = [self canonicalizedResourceWithKey:key];
     NSString* stringToSign = [self stringToSignForRequestMethod:requestMethod contentMD5:contentMD5 mimeType:mimeType dateString:dateString headers:canonicalizedAmzHeaders resource:canonicalizedResource];
-    
+
     NSString* signature = [self base64EncodedStringFromData:[self HMACSHA1WithKey:self.secretKey string:stringToSign]];
     NSString* authorizationString = [NSString stringWithFormat:@"AWS %@:%@", self.accessKey, signature];
     [self.requestSerializer setValue:authorizationString forHTTPHeaderField:@"Authorization"];
@@ -140,7 +140,6 @@
     NSMutableURLRequest* request = [self.requestSerializer requestWithMethod:requestMethod URLString:[[NSURL URLWithString:canonicalizedResource relativeToURL:self.baseURL] absoluteString] parameters:nil error:nil];
     [request addValue:[NSString stringWithFormat:@"%ld", (long)[data length]] forHTTPHeaderField:@"Content-Length"];
     [request setHTTPBody:data];
-    
     AFHTTPRequestOperation* operation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation* operation, id responseObject) {
         if (success) success(operation, responseObject);
     } failure:^(AFHTTPRequestOperation* operation, NSError* error) {
@@ -158,16 +157,16 @@
     
     NSString* dateString = [self dateString];
     [self.requestSerializer setValue:dateString forHTTPHeaderField:@"Date"];
-    
+
     NSString* canonicalizedAmzHeaders = @"";
     NSString* requestMethod = @"GET";
     NSString* canonicalizedResource = [self canonicalizedResourceWithKey:key];
     NSString* stringToSign = [self stringToSignForRequestMethod:requestMethod contentMD5:@"" mimeType:@"" dateString:dateString headers:canonicalizedAmzHeaders resource:canonicalizedResource];
-    
+
     NSString* signature = [self base64EncodedStringFromData:[self HMACSHA1WithKey:self.secretKey string:stringToSign]];
     NSString* authorizationString = [NSString stringWithFormat:@"AWS %@:%@", self.accessKey, signature];
     [self.requestSerializer setValue:authorizationString forHTTPHeaderField:@"Authorization"];
-    
+
     NSMutableURLRequest* request = [self.requestSerializer requestWithMethod:requestMethod URLString:[[NSURL URLWithString:canonicalizedResource relativeToURL:self.baseURL] absoluteString] parameters:nil error:nil];
     
     AFHTTPRequestOperation* operation = [self HTTPRequestOperationWithRequest:request success:^(AFHTTPRequestOperation* operation, id responseObject) {
@@ -178,7 +177,7 @@
     
     [operation setOutputStream:[NSOutputStream outputStreamToFileAtPath:path append:NO]];
     
-    [self.operationQueue addOperation:operation];
+	[self.operationQueue addOperation:operation];
 }
 
 
@@ -203,10 +202,10 @@
 {
     NSUInteger length = [data length];
     NSMutableData* mutableData = [NSMutableData dataWithLength:((length + 2) / 3)*  4];
-    
+
     uint8_t* input = (uint8_t*)[data bytes];
     uint8_t* output = (uint8_t*)[mutableData mutableBytes];
-    
+
     for (NSUInteger i = 0; i < length; i += 3) {
         NSUInteger value = 0;
         for (NSUInteger j = i; j < (i + 3); j++) {
@@ -215,50 +214,50 @@
                 value |= (0xFF & input[j]);
             }
         }
-        
+
         static uint8_t const kAFBase64EncodingTable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-        
+
         NSUInteger idx = (i / 3)*  4;
         output[idx + 0] = kAFBase64EncodingTable[(value >> 18) & 0x3F];
         output[idx + 1] = kAFBase64EncodingTable[(value >> 12) & 0x3F];
         output[idx + 2] = (i + 1) < length ? kAFBase64EncodingTable[(value >> 6)  & 0x3F] : '=';
         output[idx + 3] = (i + 2) < length ? kAFBase64EncodingTable[(value >> 0)  & 0x3F] : '=';
     }
-    
+
     NSString* encodedString = [[NSString alloc] initWithData:mutableData encoding:NSASCIIStringEncoding];
     return encodedString;
 }
 
 - (NSData*)HMACSHA1WithKey:(NSString*)key string:(NSString*)string
 {
-    NSData* stringData = [string dataUsingEncoding:NSUTF8StringEncoding];
-    NSData* keyData = [key dataUsingEncoding:NSUTF8StringEncoding];
-    
-    uint8_t digest[CC_SHA1_DIGEST_LENGTH] = {0};
-    
-    CCHmacContext hmacContext;
-    CCHmacInit(&hmacContext, kCCHmacAlgSHA1, [keyData bytes], [keyData length]);
-    CCHmacUpdate(&hmacContext, [stringData bytes], [stringData length]);
-    CCHmacFinal(&hmacContext, digest);
-    
-    return [NSData dataWithBytes:digest length:CC_SHA1_DIGEST_LENGTH];
+	NSData* stringData = [string dataUsingEncoding:NSUTF8StringEncoding];
+	NSData* keyData = [key dataUsingEncoding:NSUTF8StringEncoding];
+
+	uint8_t digest[CC_SHA1_DIGEST_LENGTH] = {0};
+
+	CCHmacContext hmacContext;
+	CCHmacInit(&hmacContext, kCCHmacAlgSHA1, [keyData bytes], [keyData length]);
+	CCHmacUpdate(&hmacContext, [stringData bytes], [stringData length]);
+	CCHmacFinal(&hmacContext, digest);
+
+	return [NSData dataWithBytes:digest length:CC_SHA1_DIGEST_LENGTH];
 }
 
 - (NSData*)MD5FromData:(NSData*)data
 {
     uint8_t digest[CC_MD5_DIGEST_LENGTH] = {0};
-    
+
     CC_MD5([data bytes], (int)[data length], digest);
-    
+
     return [NSData dataWithBytes:digest length:CC_MD5_DIGEST_LENGTH];
 }
 
 - (NSString*)URLEncodedStringFromString:(NSString*)string encoding:(NSStringEncoding)encoding
 {
     static NSString* const kAFLegalCharactersToBeEscaped = @"?!@#$^&%*+,:;='\"`<>()[]{}/\\|~ ";
-    
+
     // Following the suggestion in documentation for `CFURLCreateStringByAddingPercentEscapes` to "pre-process" URL strings (using stringByReplacingPercentEscapesUsingEncoding) with unpredictable sequences that may already contain percent escapes.
-    NSString* encodedURL = (__bridge_transfer NSString*)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)[string stringByReplacingPercentEscapesUsingEncoding:encoding], NULL, (__bridge CFStringRef)kAFLegalCharactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding));
+	NSString* encodedURL = (__bridge_transfer NSString*)CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (__bridge CFStringRef)[string stringByReplacingPercentEscapesUsingEncoding:encoding], NULL, (__bridge CFStringRef)kAFLegalCharactersToBeEscaped, CFStringConvertNSStringEncodingToEncoding(encoding));
     return encodedURL;
 }
 
@@ -268,7 +267,7 @@
     [dateFormatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
     [dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
     [dateFormatter setDateFormat:@"EEE, d MMM yyyy HH:mm:ss Z"];
-    
+
     return [dateFormatter stringFromDate:[NSDate date]];
 }
 


### PR DESCRIPTION
Refactoring 'putObject' selectors to internally rely on a performMethod:withData: selector that handles all of the header and signature construction, adding a new selector to expose a DELETE variant to allow for removing items from a bucket.
